### PR TITLE
fix: resolve permission issues with Coolify volume mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,9 @@ RUN --mount=type=cache,target=/app/.next/cache \
 
 FROM node:${NODE_VERSION} AS runner
 
+# Install curl for health checks and gosu for user switching
+RUN apt-get update && apt-get install -y curl gosu && rm -rf /var/lib/apt/lists/*
+
 # Set working directory
 WORKDIR /app
 
@@ -82,7 +85,7 @@ ENV HOSTNAME="0.0.0.0"
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
-# Uncomment the following line in case you want to disable telemetry during the run time.
+# Uncomment the following line in case you want to want to disable telemetry during the run time.
 # ENV NEXT_TELEMETRY_DISABLED=1
 
 # Copy production assets
@@ -90,11 +93,21 @@ COPY --from=builder --chown=node:node /app/public ./public
 COPY --from=builder --chown=node:node /app/.next/standalone ./
 COPY --from=builder --chown=node:node /app/.next/static ./.next/static
 
-# Switch to non-root user for security best practices
-USER node
+# Copy entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Create uploads directory (ownership fixed at runtime by entrypoint)
+RUN mkdir -p /app/public/uploads/images
 
 # Expose port 3000 to allow HTTP traffic
 EXPOSE 3000
 
-# Start Next.js standalone server
+# Health check for Coolify - checks if the application is responding
+# Interval: 30s, Timeout: 3s, Start period: 5s, Retries: 3
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:3000/ || exit 1
+
+# Use entrypoint to fix permissions then run as node user
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Docker entrypoint script for utvecklingsblogg
+# Ensures correct permissions for uploaded images directory
+
+set -e
+
+# Create uploads directory if it doesn't exist
+mkdir -p /app/public/uploads/images
+
+# Fix ownership to node user (UID 1000)
+# This is needed because Docker volume mounts may create directories as root
+chown -R node:node /app/public/uploads
+
+# Switch to node user and execute the main command
+exec gosu node "$@"


### PR DESCRIPTION
Add docker-entrypoint.sh to fix permission issues when using Docker volumes:
- Install gosu for reliable user switching
- Create entrypoint script that chowns uploads directory at runtime
- This ensures node user can write to volume-mounted directories
- Remove USER instruction from Dockerfile (handled by entrypoint)

The volume mount from Coolify creates directories as root, so we need to fix ownership at container startup before the app runs.